### PR TITLE
Feature: add end all ongoing games endpoint

### DIFF
--- a/src/main/kotlin/com/fcfb/arceus/controllers/GameController.kt
+++ b/src/main/kotlin/com/fcfb/arceus/controllers/GameController.kt
@@ -47,7 +47,13 @@ class GameController(
     @PostMapping("/end")
     fun endGame(
         @RequestParam("channelId") channelId: ULong,
-    ) = gameService.endGame(channelId)
+    ) = gameService.endSingleGame(channelId)
+
+    /**
+     * End all ongoing games
+     */
+    @PostMapping("/end_all")
+    fun endAllGames() = gameService.endAllGames()
 
     /**
      * Chew a game
@@ -143,6 +149,4 @@ class GameController(
     fun deleteOngoingGame(
         @RequestParam("channelId") channelId: ULong,
     ) = gameService.deleteOngoingGame(channelId)
-
-    // TODO: end game
 }

--- a/src/main/kotlin/com/fcfb/arceus/repositories/GameRepository.kt
+++ b/src/main/kotlin/com/fcfb/arceus/repositories/GameRepository.kt
@@ -21,6 +21,9 @@ interface GameRepository : CrudRepository<Game?, Int?> {
     @Query(value = "SELECT * FROM game WHERE away_platform_id = ?", nativeQuery = true)
     fun getGameByAwayPlatformId(awayPlatformId: ULong): Game?
 
+    @Query(value = "SELECT * FROM game WHERE game_status != 'FINAL' AND game_type != 'SCRIMMAGE'", nativeQuery = true)
+    fun getAllOngoingGames(): List<Game>
+
     @Query(
         value =
             "SELECT * FROM game " +

--- a/src/main/kotlin/com/fcfb/arceus/service/fcfb/game/GameService.kt
+++ b/src/main/kotlin/com/fcfb/arceus/service/fcfb/game/GameService.kt
@@ -183,17 +183,37 @@ class GameService(
     }
 
     /**
-     * End a game
+     * End all ongoing games
+     */
+    fun endAllGames(): List<Game> {
+        val gamesToEnd = gameRepository.getAllOngoingGames()
+        val endedGames = mutableListOf<Game>()
+        for (game in gamesToEnd) {
+            endedGames.add(endGame(game))
+        }
+        return endedGames
+    }
+
+    /**
+     * End a single game
      * @param channelId
      * @return
      */
-    fun endGame(channelId: ULong): Game {
+    fun endSingleGame(channelId: ULong): Game {
         val game =
             getGameByPlatformId(channelId) ?: run {
                 Logger.error("Game at $channelId not found")
                 throw Exception("Game not found")
             }
+        return endGame(game)
+    }
 
+    /**
+     * End a game
+     * @param game
+     * @return
+     */
+    private fun endGame(game: Game): Game {
         try {
             game.gameStatus = GameStatus.FINAL
             if (game.gameType != GameType.SCRIMMAGE) {


### PR DESCRIPTION
This pull request introduces several changes to enhance the functionality of ending games in the `GameController` and related classes. The most important changes include adding a method to end all ongoing games, renaming an existing method for clarity, and updating the repository to support these operations.

### Enhancements to game ending functionality:

* [`src/main/kotlin/com/fcfb/arceus/controllers/GameController.kt`](diffhunk://#diff-93fb3010bc6f42135af3a58ea33913cc51c4ee9b8ef2e3a054715119c4d4abf6L50-R56): Added a new endpoint `endAllGames` to end all ongoing games and renamed `endGame` to `endSingleGame` for clarity. [[1]](diffhunk://#diff-93fb3010bc6f42135af3a58ea33913cc51c4ee9b8ef2e3a054715119c4d4abf6L50-R56) [[2]](diffhunk://#diff-93fb3010bc6f42135af3a58ea33913cc51c4ee9b8ef2e3a054715119c4d4abf6L146-L147)

* [`src/main/kotlin/com/fcfb/arceus/repositories/GameRepository.kt`](diffhunk://#diff-06a1326d3faffefa5fd79fd27ffded22f81b0060b05a45155380f5bdbc079d4fR24-R26): Added a new query method `getAllOngoingGames` to retrieve all ongoing games that are not in the 'FINAL' status and are not 'SCRIMMAGE' type.

* [`src/main/kotlin/com/fcfb/arceus/service/fcfb/game/GameService.kt`](diffhunk://#diff-0c026095319935378e01acb443d96394130a22e41ca13eb0f6d6884f98c465eeL186-R216): Added a new method `endAllGames` to end all ongoing games and refactored the existing `endGame` method into `endSingleGame` for better clarity. Also, introduced a private method `endGame` to handle the actual game-ending logic.