### PR TITLE
Feature: add endpoints to grab games for other scenarios

### DIFF
--- a/src/main/kotlin/com/fcfb/arceus/controllers/GameController.kt
+++ b/src/main/kotlin/com/fcfb/arceus/controllers/GameController.kt
@@ -35,8 +35,29 @@ class GameController(
      * Get all ongoing games
      * @return
      */
-    @GetMapping("/all")
+    @GetMapping("/all/ongoing")
     fun getAllOngoingGames() = gameService.getAllOngoingGames()
+
+    /**
+     * Get all past games
+     * @return
+     */
+    @GetMapping("/all/past")
+    fun getAllPastGames() = gameService.getAllPastGames()
+
+    /**
+     * Get all past scrimmage games
+     * @return
+     */
+    @GetMapping("/all/past/scrimmage")
+    fun getAllPastScrimmageGames() = gameService.getAllPastScrimmageGames()
+
+    /**
+     * Get all ongoing scrimmage games
+     * @return
+     */
+    @GetMapping("/all/ongoing/scrimmage")
+    fun getAllOngoingScrimmageGames() = gameService.getAllOngoingScrimmageGames()
 
     /**
      * Start a game

--- a/src/main/kotlin/com/fcfb/arceus/repositories/GameRepository.kt
+++ b/src/main/kotlin/com/fcfb/arceus/repositories/GameRepository.kt
@@ -24,6 +24,15 @@ interface GameRepository : CrudRepository<Game?, Int?> {
     @Query(value = "SELECT * FROM game WHERE game_status != 'FINAL' AND game_type != 'SCRIMMAGE'", nativeQuery = true)
     fun getAllOngoingGames(): List<Game>
 
+    @Query(value = "SELECT * FROM game WHERE game_status = 'FINAL' AND game_type != 'SCRIMMAGE'", nativeQuery = true)
+    fun getAllPastGames(): List<Game>
+
+    @Query(value = "SELECT * FROM game WHERE game_status = 'FINAL' AND game_type = 'SCRIMMAGE'", nativeQuery = true)
+    fun getAllPastScrimmageGames(): List<Game>
+
+    @Query(value = "SELECT * FROM game WHERE game_status != 'FINAL' AND game_type == 'SCRIMMAGE'", nativeQuery = true)
+    fun getAllOngoingScrimmageGames(): List<Game>
+
     @Query(
         value =
             "SELECT * FROM game " +

--- a/src/main/kotlin/com/fcfb/arceus/service/fcfb/game/GameService.kt
+++ b/src/main/kotlin/com/fcfb/arceus/service/fcfb/game/GameService.kt
@@ -480,6 +480,12 @@ class GameService(
         return game
     }
 
+    fun getAllPastGames() = gameRepository.getAllPastGames()
+
+    fun getAllPastScrimmageGames() = gameRepository.getAllPastScrimmageGames()
+
+    fun getAllOngoingScrimmageGames() = gameRepository.getAllOngoingScrimmageGames()
+
     /**
      * Find expired timers
      */


### PR DESCRIPTION
This pull request introduces several new endpoints to the `GameController` class, along with corresponding methods in the `GameService` and `GameRepository` classes to fetch different types of game data. The most important changes include adding endpoints and methods to retrieve past games, past scrimmage games, and ongoing scrimmage games.

New endpoints in `GameController`:

* Added `@GetMapping("/all/past")` to retrieve all past games.
* Added `@GetMapping("/all/past/scrimmage")` to retrieve all past scrimmage games.
* Added `@GetMapping("/all/ongoing/scrimmage")` to retrieve all ongoing scrimmage games.

Corresponding methods in `GameService`:

* Added `getAllPastGames` method to fetch past games from the repository.
* Added `getAllPastScrimmageGames` method to fetch past scrimmage games from the repository.
* Added `getAllOngoingScrimmageGames` method to fetch ongoing scrimmage games from the repository.

Database queries in `GameRepository`:

* Added a query to fetch all past games.
* Added a query to fetch all past scrimmage games.
* Added a query to fetch all ongoing scrimmage games.