### PR TITLE
FCFB-24: Fix delay of game rollback

### DIFF
--- a/src/main/kotlin/com/fcfb/arceus/service/fcfb/game/PlayService.kt
+++ b/src/main/kotlin/com/fcfb/arceus/service/fcfb/game/PlayService.kt
@@ -265,14 +265,12 @@ class PlayService(
                 }
                 game.currentPlayType = PlayType.NORMAL
             }
-
             if (previousPlay.playCall == PlayCall.KICKOFF_NORMAL ||
                 previousPlay.playCall == PlayCall.KICKOFF_ONSIDE ||
                 previousPlay.playCall == PlayCall.KICKOFF_SQUIB
             ) {
                 game.currentPlayType = PlayType.KICKOFF
             }
-
             if (gamePlay.offensiveTimeoutCalled) {
                 if (gamePlay.possession == TeamSide.HOME) {
                     game.homeTimeouts--

--- a/src/main/kotlin/com/fcfb/arceus/tasks/DelayOfGameMonitor.kt
+++ b/src/main/kotlin/com/fcfb/arceus/tasks/DelayOfGameMonitor.kt
@@ -88,21 +88,24 @@ class DelayOfGameMonitor(
         }
 
         val currentPlay = playService.getCurrentPlay(game.gameId)
-        if (currentPlay != null) {
-            currentPlay.playFinished = true
-            currentPlay.defensiveNumber = "0"
-            currentPlay.result = Scenario.DELAY_OF_GAME
-            currentPlay.actualResult = ActualResult.DELAY_OF_GAME
-            playRepository.save(currentPlay)
-        } else {
-            val play = playService.defensiveNumberSubmitted(game.gameId, "NONE", 0, false)
-            play.playFinished = true
-            play.defensiveNumber = "0"
-            play.result = Scenario.DELAY_OF_GAME
-            play.actualResult = ActualResult.DELAY_OF_GAME
-            playRepository.save(play)
-        }
+        val savedPlay =
+            if (currentPlay != null) {
+                currentPlay.playFinished = true
+                currentPlay.defensiveNumber = "0"
+                currentPlay.result = Scenario.DELAY_OF_GAME
+                currentPlay.actualResult = ActualResult.DELAY_OF_GAME
+                playRepository.save(currentPlay)
+            } else {
+                val play = playService.defensiveNumberSubmitted(game.gameId, "NONE", 0, false)
+                play.playFinished = true
+                play.defensiveNumber = "0"
+                play.result = Scenario.DELAY_OF_GAME
+                play.actualResult = ActualResult.DELAY_OF_GAME
+                playRepository.save(play)
+            }
 
+        game.currentPlayId = savedPlay.playId
+        game.gameWarned = false
         gameService.saveGame(game)
         scorebugService.generateScorebug(game)
         return game


### PR DESCRIPTION
This pull request includes changes to improve the handling of play types and game state updates in the `PlayService` and `DelayOfGameMonitor` classes. The most important changes include adding a missing assignment for `savedPlay`, updating the current play ID, and resetting the game warning flag.

Improvements to play handling:

* [`src/main/kotlin/com/fcfb/arceus/service/fcfb/game/PlayService.kt`](diffhunk://#diff-4b95048751dadc818cca9984722ce662a08bf3480ff3c19118009adb21a76863L268-L275): Removed unnecessary blank lines to clean up the code and improve readability.

Updates to game state:

* [`src/main/kotlin/com/fcfb/arceus/tasks/DelayOfGameMonitor.kt`](diffhunk://#diff-d62571085c27be17b5699c4c4bef1904ae69db0dcff85b5c6ec8b3e6e4360292R91): Added a missing assignment for `savedPlay` to ensure the current play is properly saved.
* [`src/main/kotlin/com/fcfb/arceus/tasks/DelayOfGameMonitor.kt`](diffhunk://#diff-d62571085c27be17b5699c4c4bef1904ae69db0dcff85b5c6ec8b3e6e4360292R107-R108): Updated the current play ID and reset the game warning flag to ensure the game state is accurately maintained.