### PR TITLE
FCFB-46: automatically advance week when schedule is finished

### DIFF
--- a/src/main/kotlin/com/fcfb/arceus/repositories/ScheduleRepository.kt
+++ b/src/main/kotlin/com/fcfb/arceus/repositories/ScheduleRepository.kt
@@ -31,7 +31,10 @@ interface ScheduleRepository : CrudRepository<Schedule?, Int?> {
         team: String,
     ): String?
 
-    @Query(value = "SELECT * FROM schedule WHERE season = :season AND (home_team = :team OR away_team = :team)", nativeQuery = true)
+    @Query(
+        value = "SELECT * FROM schedule WHERE season = :season AND (home_team = :team OR away_team = :team)",
+        nativeQuery = true,
+    )
     fun getScheduleBySeasonAndTeam(
         season: Int,
         team: String,
@@ -52,4 +55,23 @@ interface ScheduleRepository : CrudRepository<Schedule?, Int?> {
         season: Int,
         week: Int,
     ): Schedule?
+
+    @Query(
+        value = """
+        SELECT 
+            CASE 
+                WHEN NOT EXISTS (
+                    SELECT 1 
+                    FROM schedule 
+                    WHERE season = :season AND week = :week AND finished = false
+                ) THEN true
+                ELSE false
+            END AS allFinished
+        """,
+        nativeQuery = true,
+    )
+    fun checkIfWeekIsOver(
+        season: Int,
+        week: Int,
+    ): Int
 }

--- a/src/main/kotlin/com/fcfb/arceus/service/fcfb/SeasonService.kt
+++ b/src/main/kotlin/com/fcfb/arceus/service/fcfb/SeasonService.kt
@@ -70,4 +70,13 @@ class SeasonService(
      * Get the current week
      */
     fun getCurrentWeek() = seasonRepository.getCurrentSeason()?.currentWeek ?: throw CurrentWeekNotFoundException()
+
+    /**
+     * Increment the current week
+     */
+    fun incrementWeek() {
+        val season = getCurrentSeason()
+        season.currentWeek = season.currentWeek.plus(1)
+        seasonRepository.save(season)
+    }
 }

--- a/src/main/kotlin/com/fcfb/arceus/service/fcfb/game/ScheduleService.kt
+++ b/src/main/kotlin/com/fcfb/arceus/service/fcfb/game/ScheduleService.kt
@@ -51,8 +51,21 @@ class ScheduleService(
         gameInSchedule?.finished = true
         if (gameInSchedule != null) {
             scheduleRepository.save(gameInSchedule)
+            if (checkIfWeekIsOver(game.season ?: 0, game.week ?: 0)) {
+                seasonService.incrementWeek()
+            }
         }
     }
+
+    /**
+     * Check if the current week is over
+     * @param season
+     * @param week
+     */
+    private fun checkIfWeekIsOver(
+        season: Int,
+        week: Int,
+    ) = scheduleRepository.checkIfWeekIsOver(season, week) == 1
 
     /**
      * Find the game in the schedule


### PR DESCRIPTION
This pull request introduces several enhancements to the scheduling and season management functionalities. The changes include adding new queries to the `ScheduleRepository`, updating the `SeasonService` to increment the current week, and modifying the `ScheduleService` to check if the current week is over and increment it accordingly.

### Enhancements to ScheduleRepository:

* Added a multi-line `@Query` annotation for better readability in the `getScheduleBySeasonAndTeam` method.
* Introduced a new query method `checkIfWeekIsOver` to determine if all games in a given week are finished.

### Updates to SeasonService:

* Added the `incrementWeek` method to increment the current week of the season.

### Modifications to ScheduleService:

* Updated the `saveGame` method to check if the current week is over and increment the week if necessary.
* Added a private method `checkIfWeekIsOver` to call the new repository method and determine if the week is over.