### PR TITLE
Feature: add sacks to stats

### DIFF
--- a/src/main/kotlin/com/fcfb/arceus/domain/GameStats.kt
+++ b/src/main/kotlin/com/fcfb/arceus/domain/GameStats.kt
@@ -71,6 +71,12 @@ class GameStats(
     @Column(name = "pass_yards")
     var passYards: Int = 0,
     @Basic
+    @Column(name = "sacks_allowed")
+    var sacksAllowed: Int = 0,
+    @Basic
+    @Column(name = "sacks_forced")
+    var sacksForced: Int = 0,
+    @Basic
     @Column(name = "rush_attempts")
     var rushAttempts: Int = 0,
     @Basic

--- a/src/main/kotlin/com/fcfb/arceus/handlers/game/PlayHandler.kt
+++ b/src/main/kotlin/com/fcfb/arceus/handlers/game/PlayHandler.kt
@@ -1179,6 +1179,8 @@ class PlayHandler(
         gamePlay.runoffTime = runoffTime
         gamePlay.difference = difference
         gamePlay.timeoutUsed = timeoutUsed
+        gamePlay.homeScore = homeScore
+        gamePlay.awayScore = awayScore
         gamePlay.playFinished = true
 
         if (initialPossession == TeamSide.HOME) {

--- a/src/main/kotlin/com/fcfb/arceus/handlers/game/StatsHandler.kt
+++ b/src/main/kotlin/com/fcfb/arceus/handlers/game/StatsHandler.kt
@@ -47,6 +47,11 @@ class StatsHandler(
             calculatePassYards(
                 play, stats.passYards,
             )
+        stats.sacksAllowed =
+            calculateSacksAllowed(
+                play, stats.sacksAllowed,
+            )
+        stats.sacksForced = opponentStats.sacksAllowed
         stats.rushAttempts =
             calculateRushAttempts(
                 play, stats.rushAttempts,
@@ -426,6 +431,16 @@ class StatsHandler(
             return currentPassYards + (play.yards)
         }
         return currentPassYards
+    }
+
+    private fun calculateSacksAllowed(
+        play: Play,
+        currentSacksAllowed: Int,
+    ): Int {
+        if (play.playCall == PlayCall.PASS && play.actualResult == ActualResult.LOSS) {
+            return currentSacksAllowed + 1
+        }
+        return currentSacksAllowed
     }
 
     private fun calculateRushAttempts(

--- a/src/main/kotlin/com/fcfb/arceus/service/fcfb/game/GameStatsService.kt
+++ b/src/main/kotlin/com/fcfb/arceus/service/fcfb/game/GameStatsService.kt
@@ -39,7 +39,7 @@ class GameStatsService(
                 subdivision = game.subdivision,
                 gameStatus = game.gameStatus,
                 gameType = game.gameType,
-                record = homeTeam.currentWins.toString() + "-" + homeTeam.currentLosses.toString(),
+                record = game.homeWins.toString() + "-" + game.homeLosses.toString(),
             )
         gameStatsRepository.save(homeStats) ?: throw Exception("Could not create game stats")
 
@@ -57,7 +57,7 @@ class GameStatsService(
                 subdivision = game.subdivision,
                 gameStatus = game.gameStatus,
                 gameType = game.gameType,
-                record = awayTeam.currentWins.toString() + "-" + awayTeam.currentLosses.toString(),
+                record = game.awayWins.toString() + "-" + game.awayLosses.toString(),
             )
         gameStatsRepository.save(awayStats) ?: throw Exception("Could not create game stats")
 


### PR DESCRIPTION
This pull request includes several changes to the `GameStats`, `PlayHandler`, `StatsHandler`, and `GameStatsService` classes to enhance the tracking and handling of game statistics. The most important changes are summarized below:

### Enhancements to Game Statistics Tracking:

* [`src/main/kotlin/com/fcfb/arceus/domain/GameStats.kt`](diffhunk://#diff-4dd2bfd871005b446ef64ceafae036775c13b6949066151826f37c8eca8171deR74-R79): Added new fields `sacksAllowed` and `sacksForced` to track the number of sacks allowed and forced in a game.

### Updates to Play Handling:

* [`src/main/kotlin/com/fcfb/arceus/handlers/game/PlayHandler.kt`](diffhunk://#diff-7015c1d837573376a2ddbaa7e88d030e4bc66dd526392a91e29724baad807283R1182-R1183): Added `homeScore` and `awayScore` fields to the `gamePlay` object to keep track of the scores during a play.

### Updates to Stats Handling:

* [`src/main/kotlin/com/fcfb/arceus/handlers/game/StatsHandler.kt`](diffhunk://#diff-97b68102b6b6ff04095f049fe857b876317fae29f2c03127e303e2567aa7bb37R50-R54): Added logic to calculate and update the number of sacks allowed and forced during a game. [[1]](diffhunk://#diff-97b68102b6b6ff04095f049fe857b876317fae29f2c03127e303e2567aa7bb37R50-R54) [[2]](diffhunk://#diff-97b68102b6b6ff04095f049fe857b876317fae29f2c03127e303e2567aa7bb37R436-R445)

### Updates to Game Stats Service:

* [`src/main/kotlin/com/fcfb/arceus/service/fcfb/game/GameStatsService.kt`](diffhunk://#diff-691c2d45502e3ab2719c0cda28c3326cc1d917c79b5e40c2fa9abf26d2558919L42-R42): Modified the calculation of the `record` field to use `game.homeWins` and `game.homeLosses` for the home team, and `game.awayWins` and `game.awayLosses` for the away team, instead of using `homeTeam` and `awayTeam` objects. [[1]](diffhunk://#diff-691c2d45502e3ab2719c0cda28c3326cc1d917c79b5e40c2fa9abf26d2558919L42-R42) [[2]](diffhunk://#diff-691c2d45502e3ab2719c0cda28c3326cc1d917c79b5e40c2fa9abf26d2558919L60-R60)