### PR TITLE
Bugfix: fix records for final scores on scorebugs

### DIFF
--- a/src/main/kotlin/com/fcfb/arceus/service/fcfb/game/ScorebugService.kt
+++ b/src/main/kotlin/com/fcfb/arceus/service/fcfb/game/ScorebugService.kt
@@ -364,9 +364,25 @@ class ScorebugService(
         // Draw the team record
         val record =
             if (team.name == game.homeTeam) {
-                "${game.homeWins}-${game.homeLosses}"
+                if (game.gameStatus == GameStatus.FINAL) {
+                    if (game.homeScore > game.awayScore) {
+                        "${game.homeWins?.plus(1)}-${game.homeLosses}"
+                    } else {
+                        "${game.homeWins}-${game.homeLosses?.plus(1)}"
+                    }
+                } else {
+                    "${game.homeWins}-${game.homeLosses}"
+                }
             } else {
-                "${game.awayWins}-${game.awayLosses}"
+                if (game.gameStatus == GameStatus.FINAL) {
+                    if (game.awayScore > game.homeScore) {
+                        "${game.awayWins?.plus(1)}-${game.awayLosses}"
+                    } else {
+                        "${game.awayWins}-${game.awayLosses?.plus(1)}"
+                    }
+                } else {
+                    "${game.awayWins}-${game.awayLosses}"
+                }
             }
         g.font = Font.createFont(Font.TRUETYPE_FONT, getHelveticaFont(g)).deriveFont(Font.PLAIN, 33f)
         g.color = Color(255, 255, 255)


### PR DESCRIPTION
This pull request includes changes to the `ScorebugService` class to correctly update the team record based on the game status. The most important change ensures that the team record reflects the outcome of the game if it has reached a final status.

Updates to `ScorebugService`:

* [`src/main/kotlin/com/fcfb/arceus/service/fcfb/game/ScorebugService.kt`](diffhunk://#diff-6c2218846a9c582e125f5634c427a3ad0a210a7318f7437128549448e78e5dcaR367-R386): Added logic to update the team record to account for the final game status, adjusting the win/loss record based on the game outcome.