### PR TITLE
Bugfix: fix nola not being able to use sub coachg

### DIFF
--- a/src/main/kotlin/com/fcfb/arceus/repositories/TeamRepository.kt
+++ b/src/main/kotlin/com/fcfb/arceus/repositories/TeamRepository.kt
@@ -10,6 +10,7 @@ interface TeamRepository : CrudRepository<Team?, Int?> {
     @Query(value = "SELECT * FROM team WHERE conference = :conference", nativeQuery = true)
     fun getTeamsInConference(conference: String): List<Team>?
 
+    @Query("SELECT * FROM team t WHERE LOWER(t.name) = LOWER(:name)", nativeQuery = true)
     fun getTeamByName(name: String?): Team
 
     @Query(

--- a/src/main/kotlin/com/fcfb/arceus/service/fcfb/game/GameService.kt
+++ b/src/main/kotlin/com/fcfb/arceus/service/fcfb/game/GameService.kt
@@ -583,12 +583,12 @@ class GameService(
         val userData = userService.getUserDTOByDiscordId(discordId)
         val coach = userData.discordTag
 
-        when (team) {
-            game.homeTeam -> {
+        when (team.lowercase()) {
+            game.homeTeam.lowercase() -> {
                 game.homeCoaches = listOf(coach)
                 game.homeCoachDiscordIds = listOf(userData.discordId ?: throw NoCoachDiscordIdsFoundException())
             }
-            game.awayTeam -> {
+            game.awayTeam.lowercase() -> {
                 game.awayCoaches = listOf(coach)
                 game.awayCoachDiscordIds = listOf(userData.discordId ?: throw NoCoachDiscordIdsFoundException())
             }


### PR DESCRIPTION
This pull request includes changes to the `TeamRepository` and `GameService` classes to enhance functionality and improve case-insensitivity handling.

Enhancements to `TeamRepository`:

* Added a new method `getTeamByName` to retrieve a team by its name, with case-insensitive matching. (`src/main/kotlin/com/fcfb/arceus/repositories/TeamRepository.kt`)

Improvements to `GameService`:

* Modified the team comparison logic to be case-insensitive by converting both `team` and `game` team names to lowercase before comparison. (`src/main/kotlin/com/fcfb/arceus/service/fcfb/game/GameService.kt`)