### PR TITLE
Bugfix: when hiring coach, mark team as taken

### DIFF
--- a/src/main/kotlin/com/fcfb/arceus/service/fcfb/TeamService.kt
+++ b/src/main/kotlin/com/fcfb/arceus/service/fcfb/TeamService.kt
@@ -343,6 +343,7 @@ class TeamService(
         }
 
         withContext(Dispatchers.IO) {
+            existingTeam.isTaken = true
             saveTeam(existingTeam)
             userService.updateUser(user)
             coachTransactionLogService.logCoachTransaction(
@@ -430,6 +431,7 @@ class TeamService(
         existingTeam.coachDiscordIds = null
         existingTeam.offensivePlaybook = OffensivePlaybook.AIR_RAID
         existingTeam.defensivePlaybook = DefensivePlaybook.FOUR_THREE
+        existingTeam.isTaken = false
         saveTeam(existingTeam)
         return existingTeam
     }


### PR DESCRIPTION
This pull request includes changes to the `TeamService` class in the `src/main/kotlin/com/fcfb/arceus/service/fcfb/TeamService.kt` file to manage the `isTaken` status of teams more effectively.

Most important changes:

* In the `withContext(Dispatchers.IO)` block, the `isTaken` property of `existingTeam` is set to `true` before saving the team.
* In another part of the `TeamService` class, the `isTaken` property of `existingTeam` is set to `false` before saving the team.