### PR TITLE
Bugfix: fix registration so it properly handles signups

### DIFF
--- a/src/main/kotlin/com/fcfb/arceus/domain/NewSignup.kt
+++ b/src/main/kotlin/com/fcfb/arceus/domain/NewSignup.kt
@@ -42,6 +42,10 @@ class NewSignup {
     lateinit var email: String
 
     @Basic
+    @Column(name = "hashed_email")
+    lateinit var hashedEmail: String
+
+    @Basic
     @Column(name = "password")
     lateinit var password: String
 
@@ -90,6 +94,7 @@ class NewSignup {
         discordTag: String,
         discordId: String?,
         email: String,
+        hashedEmail: String,
         password: String,
         position: CoachPosition,
         salt: String,
@@ -106,6 +111,7 @@ class NewSignup {
         this.discordTag = discordTag
         this.discordId = discordId
         this.email = email
+        this.hashedEmail = hashedEmail
         this.password = password
         this.position = position
         this.salt = salt

--- a/src/main/kotlin/com/fcfb/arceus/repositories/NewSignupRepository.kt
+++ b/src/main/kotlin/com/fcfb/arceus/repositories/NewSignupRepository.kt
@@ -12,5 +12,7 @@ interface NewSignupRepository : CrudRepository<NewSignup?, String?> {
     @Query("SELECT * FROM new_signup", nativeQuery = true)
     fun getNewSignups(): List<NewSignup>
 
+    fun getByDiscordId(discordId: String?): NewSignup?
+
     fun getByVerificationToken(token: String?): NewSignup
 }

--- a/src/main/kotlin/com/fcfb/arceus/service/auth/AuthService.kt
+++ b/src/main/kotlin/com/fcfb/arceus/service/auth/AuthService.kt
@@ -1,7 +1,6 @@
 package com.fcfb.arceus.service.auth
 
 import com.fcfb.arceus.domain.NewSignup
-import com.fcfb.arceus.domain.User
 import com.fcfb.arceus.models.website.LoginResponse
 import com.fcfb.arceus.service.email.EmailService
 import com.fcfb.arceus.service.fcfb.NewSignupService

--- a/src/main/kotlin/com/fcfb/arceus/service/auth/AuthService.kt
+++ b/src/main/kotlin/com/fcfb/arceus/service/auth/AuthService.kt
@@ -1,6 +1,7 @@
 package com.fcfb.arceus.service.auth
 
 import com.fcfb.arceus.domain.NewSignup
+import com.fcfb.arceus.domain.User
 import com.fcfb.arceus.models.website.LoginResponse
 import com.fcfb.arceus.service.email.EmailService
 import com.fcfb.arceus.service.fcfb.NewSignupService

--- a/src/main/kotlin/com/fcfb/arceus/service/fcfb/NewSignupService.kt
+++ b/src/main/kotlin/com/fcfb/arceus/service/fcfb/NewSignupService.kt
@@ -93,7 +93,7 @@ class NewSignupService(
                     averageResponseTime = 0.0,
                     resetToken = null,
                     resetTokenExpiration = null,
-                )
+                ),
             )
             return true
         } catch (e: Exception) {

--- a/src/main/kotlin/com/fcfb/arceus/service/fcfb/NewSignupService.kt
+++ b/src/main/kotlin/com/fcfb/arceus/service/fcfb/NewSignupService.kt
@@ -2,6 +2,7 @@ package com.fcfb.arceus.service.fcfb
 
 import com.fcfb.arceus.converter.DTOConverter
 import com.fcfb.arceus.domain.NewSignup
+import com.fcfb.arceus.domain.User
 import com.fcfb.arceus.models.dto.NewSignupDTO
 import com.fcfb.arceus.repositories.NewSignupRepository
 import com.fcfb.arceus.utils.EncryptionUtils
@@ -13,6 +14,7 @@ import java.util.UUID
 class NewSignupService(
     private val dtoConverter: DTOConverter,
     private val encryptionUtils: EncryptionUtils,
+    private val userService: UserService,
     private val newSignupRepository: NewSignupRepository,
 ) {
     /**
@@ -31,6 +33,7 @@ class NewSignupService(
                 newSignup.discordTag,
                 newSignup.discordId,
                 encryptionUtils.encrypt(newSignup.email),
+                encryptionUtils.hash(newSignup.email),
                 passwordEncoder.encode(newSignup.password),
                 newSignup.position,
                 salt,
@@ -58,6 +61,40 @@ class NewSignupService(
                 approved = true
             }
             saveNewSignup(newSignup)
+            userService.saveUser(
+                User(
+                    username = newSignup.username,
+                    coachName = newSignup.coachName,
+                    discordTag = newSignup.discordTag,
+                    discordId = newSignup.discordId,
+                    email = newSignup.email,
+                    hashedEmail = newSignup.hashedEmail,
+                    password = newSignup.password,
+                    position = newSignup.position,
+                    role = User.Role.USER,
+                    salt = newSignup.salt,
+                    team = null,
+                    delayOfGameInstances = 0,
+                    wins = 0,
+                    losses = 0,
+                    winPercentage = 0.0,
+                    conferenceWins = 0,
+                    conferenceLosses = 0,
+                    conferenceChampionshipWins = 0,
+                    conferenceChampionshipLosses = 0,
+                    bowlWins = 0,
+                    bowlLosses = 0,
+                    playoffWins = 0,
+                    playoffLosses = 0,
+                    nationalChampionshipWins = 0,
+                    nationalChampionshipLosses = 0,
+                    offensivePlaybook = newSignup.offensivePlaybook,
+                    defensivePlaybook = newSignup.defensivePlaybook,
+                    averageResponseTime = 0.0,
+                    resetToken = null,
+                    resetTokenExpiration = null,
+                )
+            )
             return true
         } catch (e: Exception) {
             return false
@@ -69,6 +106,11 @@ class NewSignupService(
      * @param id
      */
     fun getNewSignupById(id: Long) = newSignupRepository.getById(id)
+
+    /**
+     * Get a new signup by its Discord id
+     */
+    fun getNewSignupByDiscordId(discordId: String) = newSignupRepository.getByDiscordId(discordId)
 
     /**
      * Get a new signup by its verification token
@@ -89,4 +131,10 @@ class NewSignupService(
      * @param newSignup
      */
     fun saveNewSignup(newSignup: NewSignup) = newSignupRepository.save(newSignup)
+
+    /**
+     * Delete a new signup
+     * @param id
+     */
+    fun deleteNewSignup(newSignup: NewSignup) = newSignupRepository.delete(newSignup)
 }

--- a/src/main/kotlin/com/fcfb/arceus/service/fcfb/TeamService.kt
+++ b/src/main/kotlin/com/fcfb/arceus/service/fcfb/TeamService.kt
@@ -35,6 +35,7 @@ class TeamService(
     private val teamRepository: TeamRepository,
     private val userService: UserService,
     private val coachTransactionLogService: CoachTransactionLogService,
+    private val newSignupService: NewSignupService,
 ) {
     /**
      * After a game ends, update the team's wins and losses
@@ -346,6 +347,10 @@ class TeamService(
             existingTeam.isTaken = true
             saveTeam(existingTeam)
             userService.updateUser(user)
+            val signupObject = newSignupService.getNewSignupByDiscordId(discordId)
+            if (signupObject != null) {
+                newSignupService.deleteNewSignup(signupObject)
+            }
             coachTransactionLogService.logCoachTransaction(
                 CoachTransactionLog(
                     existingTeam.name ?: "TEAM_NOT_FOUND",
@@ -383,6 +388,10 @@ class TeamService(
 
         withContext(Dispatchers.IO) {
             saveTeam(existingTeam)
+            val signupObject = newSignupService.getNewSignupByDiscordId(discordId)
+            if (signupObject != null) {
+                newSignupService.deleteNewSignup(signupObject)
+            }
             coachTransactionLogService.logCoachTransaction(
                 CoachTransactionLog(
                     existingTeam.name ?: "TEAM_NOT_FOUND",

--- a/src/main/kotlin/com/fcfb/arceus/service/fcfb/UserService.kt
+++ b/src/main/kotlin/com/fcfb/arceus/service/fcfb/UserService.kt
@@ -4,7 +4,6 @@ import com.fcfb.arceus.converter.DTOConverter
 import com.fcfb.arceus.domain.Game
 import com.fcfb.arceus.domain.Game.GameType
 import com.fcfb.arceus.domain.User
-import com.fcfb.arceus.domain.User.Role.USER
 import com.fcfb.arceus.models.dto.UserDTO
 import com.fcfb.arceus.models.requests.UserValidationRequest
 import com.fcfb.arceus.models.response.UserValidationResponse

--- a/src/main/kotlin/com/fcfb/arceus/service/fcfb/UserService.kt
+++ b/src/main/kotlin/com/fcfb/arceus/service/fcfb/UserService.kt
@@ -108,53 +108,6 @@ class UserService(
     }
 
     /**
-     * Create a new user
-     * @param user
-     */
-    fun createUser(user: User): User {
-        val passwordEncoder = BCryptPasswordEncoder()
-        val salt = passwordEncoder.encode(user.password)
-        val verificationToken = UUID.randomUUID().toString()
-
-        val newUser =
-            User(
-                user.username,
-                user.coachName,
-                user.discordTag,
-                user.discordId,
-                encryptionUtils.encrypt(user.email),
-                encryptionUtils.hash(user.email),
-                passwordEncoder.encode(user.password),
-                user.position,
-                USER,
-                salt,
-                null,
-                0,
-                0,
-                0,
-                0.0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                user.offensivePlaybook,
-                user.defensivePlaybook,
-                0.0,
-                null,
-                null,
-            )
-
-        saveUser(newUser)
-        return newUser
-    }
-
-    /**
      * Get a user DTO by its ID
      * @param id
      */


### PR DESCRIPTION
This pull request includes several changes to the `NewSignup` domain, repository, and related services to support hashed email storage and user creation. The most important changes include adding a new `hashedEmail` field, updating the `NewSignupService` to handle user creation, and modifying the `TeamService` to delete new signups upon team assignment.

### Changes to support hashed email storage:

* [`src/main/kotlin/com/fcfb/arceus/domain/NewSignup.kt`](diffhunk://#diff-79b8803df4f2cece647fe5466f74687426e62fe41e10bd715baf19bff95c9d6fR44-R47): Added a new `hashedEmail` field and updated the constructor to include this field. [[1]](diffhunk://#diff-79b8803df4f2cece647fe5466f74687426e62fe41e10bd715baf19bff95c9d6fR44-R47) [[2]](diffhunk://#diff-79b8803df4f2cece647fe5466f74687426e62fe41e10bd715baf19bff95c9d6fR97) [[3]](diffhunk://#diff-79b8803df4f2cece647fe5466f74687426e62fe41e10bd715baf19bff95c9d6fR114)

### Changes to `NewSignupService`:

* [`src/main/kotlin/com/fcfb/arceus/service/fcfb/NewSignupService.kt`](diffhunk://#diff-8381b8aa800f5addefdcbd33b3b5aeb51b906727d98ecefdb02f01a7d2bab793R5): Updated the service to include `hashedEmail` in the encryption process and added user creation logic. [[1]](diffhunk://#diff-8381b8aa800f5addefdcbd33b3b5aeb51b906727d98ecefdb02f01a7d2bab793R5) [[2]](diffhunk://#diff-8381b8aa800f5addefdcbd33b3b5aeb51b906727d98ecefdb02f01a7d2bab793R17) [[3]](diffhunk://#diff-8381b8aa800f5addefdcbd33b3b5aeb51b906727d98ecefdb02f01a7d2bab793R36) [[4]](diffhunk://#diff-8381b8aa800f5addefdcbd33b3b5aeb51b906727d98ecefdb02f01a7d2bab793R64-R97) [[5]](diffhunk://#diff-8381b8aa800f5addefdcbd33b3b5aeb51b906727d98ecefdb02f01a7d2bab793R110-R114) [[6]](diffhunk://#diff-8381b8aa800f5addefdcbd33b3b5aeb51b906727d98ecefdb02f01a7d2bab793R134-R139)

### Changes to `TeamService`:

* [`src/main/kotlin/com/fcfb/arceus/service/fcfb/TeamService.kt`](diffhunk://#diff-6012ca8033edaa20f00108e2d674968ee462cfde93b6fe0eddf7fb9dd4987046R38): Added logic to delete new signups when a team is assigned to a user. [[1]](diffhunk://#diff-6012ca8033edaa20f00108e2d674968ee462cfde93b6fe0eddf7fb9dd4987046R38) [[2]](diffhunk://#diff-6012ca8033edaa20f00108e2d674968ee462cfde93b6fe0eddf7fb9dd4987046R350-R353) [[3]](diffhunk://#diff-6012ca8033edaa20f00108e2d674968ee462cfde93b6fe0eddf7fb9dd4987046R391-R394)

### Repository updates:

* [`src/main/kotlin/com/fcfb/arceus/repositories/NewSignupRepository.kt`](diffhunk://#diff-8aaca4a6be27925501689e457581402da5291006a19dbbc1b365c58e42c2f04bR15-R16): Added a method to retrieve new signups by Discord ID.

### Code cleanup:

* [`src/main/kotlin/com/fcfb/arceus/service/fcfb/UserService.kt`](diffhunk://#diff-fbc4bfec1a2694bc9ede136bcdd2267cd6af5bf6fb9edea43d054495898d7151L110-L156): Removed the `createUser` method as the user creation logic has been moved to `NewSignupService`.