### PR TITLE
Bugfix: fix end of quarter play time

### DIFF
--- a/src/main/kotlin/com/fcfb/arceus/service/fcfb/PlayService.kt
+++ b/src/main/kotlin/com/fcfb/arceus/service/fcfb/PlayService.kt
@@ -1410,7 +1410,7 @@ class PlayService(
                     playTime,
                 )
             if (updatedQuarter != quarter) {
-                finalPlayTime = clock  + (420 - updatedClock)
+                finalPlayTime = clock + (420 - updatedClock)
             }
             possession = updatedPossession
             clock = updatedClock

--- a/src/main/kotlin/com/fcfb/arceus/service/fcfb/PlayService.kt
+++ b/src/main/kotlin/com/fcfb/arceus/service/fcfb/PlayService.kt
@@ -1394,6 +1394,7 @@ class PlayService(
         var clock = gamePlay.clock.minus(runoffTime)
         var quarter = gamePlay.quarter
         var possession = initialPossession
+        var finalPlayTime = playTime
 
         if (playCall != PlayCall.PAT && playCall != PlayCall.TWO_POINT) {
             val (updatedPossession, updatedClock, updatedQuarter) =
@@ -1408,6 +1409,9 @@ class PlayService(
                     awayScore,
                     playTime,
                 )
+            if (updatedQuarter != quarter) {
+                finalPlayTime = clock  + (420 - updatedClock)
+            }
             possession = updatedPossession
             clock = updatedClock
             quarter = updatedQuarter
@@ -1442,7 +1446,7 @@ class PlayService(
         gamePlay.result = result
         gamePlay.actualResult = actualResult
         gamePlay.yards = yards
-        gamePlay.playTime = playTime
+        gamePlay.playTime = finalPlayTime
         gamePlay.runoffTime = runoffTime
         gamePlay.difference = difference
         gamePlay.timeoutUsed = timeoutUsed


### PR DESCRIPTION
This pull request includes changes to the `PlayService` class in the `src/main/kotlin/com/fcfb/arceus/service/fcfb/PlayService.kt` file to properly handle the play time when the quarter changes during a play. The most important changes are the addition of a new variable `finalPlayTime` and its usage to update the play time correctly.

Changes to handle play time:

* Added a new variable `finalPlayTime` to store the play time (`src/main/kotlin/com/fcfb/arceus/service/fcfb/PlayService.kt`).
* Updated `finalPlayTime` when the quarter changes during a play (`src/main/kotlin/com/fcfb/arceus/service/fcfb/PlayService.kt`).
* Modified the assignment of `gamePlay.playTime` to use `finalPlayTime` instead of `playTime` (`src/main/kotlin/com/fcfb/arceus/service/fcfb/PlayService.kt`).